### PR TITLE
Allow setting templates & netvms via pillar

### DIFF
--- a/build-infra/dom0.sls
+++ b/build-infra/dom0.sls
@@ -1,17 +1,17 @@
 build-logs:
   qvm.vm:
     - present:
-        - label: green
+      - label: green
     - prefs:
-        - template: fedora-24
-        - netvm: sys-firewall
+      - template: fedora-24
+      - netvm: sys-firewall
 
 /etc/qubes-rpc/policy/qubes.Gpg:
   file.prepend:
     - text:
 {%- for env in salt['pillar.get']('build-infra:build-envs', []) %}
-        - build-{{env}} keys-{{env}} allow
-        - $anyvm keys-{{env}} deny
+      - build-{{env}} keys-{{env}} allow
+      - $anyvm keys-{{env}} deny
 {% endfor %}
 
 
@@ -22,10 +22,10 @@ build-logs:
 build-{{env}}:
   qvm.vm:
     - present:
-       - label: green
+      - label: green
     - prefs:
-       - template: fedora-24
-       - netvm: sys-whonix
+      - template: fedora-24
+      - netvm: sys-whonix
 
 keys-{{env}}:
   qvm.vm:

--- a/build-infra/dom0.sls
+++ b/build-infra/dom0.sls
@@ -3,8 +3,8 @@ build-logs:
     - present:
       - label: green
     - prefs:
-      - template: fedora-24
-      - netvm: sys-firewall
+      - template: {{ salt['pillar.get']('build-infra:logs-template', 'fedora-24') }}
+      - netvm: {{ salt['pillar.get']('build-infra:logs-netvm', 'sys-firewall') }}
 
 /etc/qubes-rpc/policy/qubes.Gpg:
   file.prepend:
@@ -24,15 +24,15 @@ build-{{env}}:
     - present:
       - label: green
     - prefs:
-      - template: fedora-24
-      - netvm: sys-whonix
+      - template: {{ salt['pillar.get']('build-infra:build-template', 'fedora-24') }}
+      - netvm: {{ salt['pillar.get']('build-infra:build-netvm', 'sys-whonix') }}
 
 keys-{{env}}:
   qvm.vm:
     - present:
       - label: black
     - prefs:
-      - template: fedora-24-minimal
+      - template: {{ salt['pillar.get']('build-infra:keys-template', 'fedora-24-minimal') }}
       - netvm: none
 
 /etc/qubes-rpc/policy/qubesbuilder.LogReceived+build-{{env}}:

--- a/build-infra/init.top
+++ b/build-infra/init.top
@@ -1,9 +1,9 @@
 base:
   dom0:
     - build-infra.dom0
-  fedora-24:
+  {{ salt['pillar.get']('build-infra:build-template', 'fedora-24') }}:
     - build-infra.template-build
-  fedora-24-minimal:
+  {{ salt['pillar.get']('build-infra:keys-template', 'fedora-24-minimal') }}:
     - build-infra.template-keys
   build-logs:
     - build-infra.build-logs

--- a/pillar/build-infra/init.sls
+++ b/pillar/build-infra/init.sls
@@ -5,6 +5,12 @@ build-infra:
   build-envs:
     - fedora
     - debian
+# Default NetVMs and templates:
+#  logs-template: fedora-24
+#  logs-netvm: sys-firewall
+#  build-template: fedora-24
+#  build-netvm: sys-whonix
+#  keys-template: fedora-24-minimal
 
 # builders in build VMs - this is just example, should be specified per-target
 # VM


### PR DESCRIPTION
for build-\*, keys-\*, build-logs

This allows keeping the default templates as-is and using a specified clone of them instead, and allows specifying different ProxyVMs (for example a caching proxy (itself behind sys-whonix) for builders), without needing to directly modify the sls files replaced by newer versions of the dom0 rpm or modifying the VMs manually after salt.

Defaults in pillar are commented out, to illustrate what to put there, but without overriding the default values in the template. This preserves the ability to update the default to e.g. fedora-25 without being overridden by old values in %config(noreplace).

I am still new to Salt, so if this is not the proper way, don't hesitate to call me out.