### PR TITLE
Add PyYAML to builder packages

### DIFF
--- a/build-infra/template-build.sls
+++ b/build-infra/template-build.sls
@@ -14,6 +14,7 @@ builder-dependencies:
       - wget
       - curl
       - qubes-gpg-split
+      - PyYAML
 # for salt gpg module
       - gnupg
       - python2-gnupg


### PR DESCRIPTION
It's a dependency when using mgmt builder plugin, and causes
manual `./setup` to be required after applying salt states.