### PR TITLE
Safely checkout qubes-builder

### DIFF
--- a/build-infra/build-vm.sls
+++ b/build-infra/build-vm.sls
@@ -220,7 +220,7 @@ github.com:
 {{builder}}-check:
   cmd.script:
     - source: salt://build-infra/safe-checkout-sha
-    - args: ['--', 'https://git@github.com/QubesOS/qubes-builder', {{ builder|yaml_encode }}, 'e8293887c39a5e39fe70d2e96564681a37ef8248']
+    - args: ['--', 'https://github.com/QubesOS/qubes-builder', {{ builder|yaml_encode }}, 'e8293887c39a5e39fe70d2e96564681a37ef8248']
     - runas: user
     - creates: {{builder}}
     - require:

--- a/build-infra/build-vm.sls
+++ b/build-infra/build-vm.sls
@@ -222,6 +222,7 @@ github.com:
     - source: salt://build-infra/safe-checkout-sha
     - args: ['--', 'https://git@github.com/QubesOS/qubes-builder', {{ builder|yaml_encode }}, 'e8293887c39a5e39fe70d2e96564681a37ef8248']
     - runas: user
+    - creates: {{builder}}
     - require:
       - gpg: {{qubes_master_key_fpr}}
 

--- a/build-infra/build-vm.sls
+++ b/build-infra/build-vm.sls
@@ -4,6 +4,12 @@
 {% set env = grains['id']|replace('build-','') %}
 {% set builders_list = salt['pillar.get']('build-infra:build-envs:' + env + ':builders-list').keys() %}
 {% set last_builder_dir = builders_list|last %}
+{%- for builder in builders_list %}
+{#- check that builder names are reasonable #}
+{#- I couldn’t find a way to fail with a decent message, so a ZeroDivisionError
+    will have to do #}
+{%- if not (builder | regex_match('^[A-Za-z][A-Za-z0-9_-]*$')) -%}{{ 0/0 }}{%- endif %}
+{%- endfor %}
 
 /usr/local/etc/qubes-rpc/qubesbuilder.CopyTemplateBack:
   file.symlink:

--- a/build-infra/build-vm.sls
+++ b/build-infra/build-vm.sls
@@ -206,7 +206,7 @@ github.com:
 {% endif %}
 
 {% for builder in builders_list %}
-{% set config_baseurl = salt['pillar.get']('build-infra:build-envs:' + env + ':builders-list:' + builder + ':config:repository:baseurl', 'ssh://github.com/QubesOS/qubes-') %}
+{% set config_baseurl = salt['pillar.get']('build-infra:build-envs:' + env + ':builders-list:' + builder + ':config:repository:baseurl', 'https://github.com/QubesOS/qubes-') %}
 {% set config_repo = salt['pillar.get']('build-infra:build-envs:' + env + ':builders-list:' + builder + ':config:repository:component', 'release-configs') %}
 {% set config_file = salt['pillar.get']('build-infra:build-envs:' + env + ':builders-list:' + builder + ':config:file') %}
 {% set keys =  salt['pillar.get']('build-infra:build-envs:' + env + ':builders-list:' + builder + ':keys', []) %}
@@ -214,14 +214,14 @@ github.com:
 {{builder}}-check:
   cmd.script:
     - source: salt://build-infra/safe-checkout-sha
-    - args: ['--', 'ssh://git@github.com/QubesOS/qubes-builder', {{ builder|yaml_encode }}, 'e8293887c39a5e39fe70d2e96564681a37ef8248']
+    - args: ['--', 'https://git@github.com/QubesOS/qubes-builder', {{ builder|yaml_encode }}, 'e8293887c39a5e39fe70d2e96564681a37ef8248']
     - runas: user
     - require:
       - gpg: {{qubes_master_key_fpr}}
 
 {{builder}}-init:
   cmd.run:
-    - name: "BUILDERCONF= GIT_URL_builder=ssh://github.com/QubesOS/qubes-builder COMPONENTS=builder make get-sources"
+    - name: "BUILDERCONF= GIT_URL_builder=https://github.com/QubesOS/qubes-builder COMPONENTS=builder make get-sources"
     - cwd: {{ builder }}
     - runas: user
     - require:

--- a/build-infra/build-vm.sls
+++ b/build-infra/build-vm.sls
@@ -206,29 +206,22 @@ github.com:
 {% endif %}
 
 {% for builder in builders_list %}
-{% set config_baseurl = salt['pillar.get']('build-infra:build-envs:' + env + ':builders-list:' + builder + ':config:repository:baseurl', 'https://github.com/QubesOS/qubes-') %}
+{% set config_baseurl = salt['pillar.get']('build-infra:build-envs:' + env + ':builders-list:' + builder + ':config:repository:baseurl', 'ssh://github.com/QubesOS/qubes-') %}
 {% set config_repo = salt['pillar.get']('build-infra:build-envs:' + env + ':builders-list:' + builder + ':config:repository:component', 'release-configs') %}
 {% set config_file = salt['pillar.get']('build-infra:build-envs:' + env + ':builders-list:' + builder + ':config:file') %}
 {% set keys =  salt['pillar.get']('build-infra:build-envs:' + env + ':builders-list:' + builder + ':keys', []) %}
 
-{{builder}}-get:
-  git.latest:
-    - name : https://github.com/QubesOS/qubes-builder
-    - target: {{ builder }}
-    - user: user
-
 {{builder}}-check:
-  cmd.run:
-    - name: git verify-tag --raw "$(git describe)" 2>&1 >/dev/null | grep '^\[GNUPG:\] TRUST_FULLY'
-    - cwd: {{ builder }}
+  cmd.script:
+    - source: salt://build-infra/safe-checkout-sha
+    - args: ['--', 'ssh://git@github.com/QubesOS/qubes-builder', {{ builder|yaml_encode }}, 'e8293887c39a5e39fe70d2e96564681a37ef8248']
     - runas: user
     - require:
-      - git: {{builder}}-get
       - gpg: {{qubes_master_key_fpr}}
 
 {{builder}}-init:
   cmd.run:
-    - name: "BUILDERCONF= GIT_URL_builder=https://github.com/QubesOS/qubes-builder COMPONENTS=builder make get-sources"
+    - name: "BUILDERCONF= GIT_URL_builder=ssh://github.com/QubesOS/qubes-builder COMPONENTS=builder make get-sources"
     - cwd: {{ builder }}
     - runas: user
     - require:
@@ -242,6 +235,7 @@ github.com:
     - runas: user
     - require:
       - cmd: {{builder}}-init
+      - cmd: {{builder}}-check
 {% endfor %}
 
 {{builder}}-configs:

--- a/build-infra/safe-checkout-sha
+++ b/build-infra/safe-checkout-sha
@@ -1,0 +1,22 @@
+#!/bin/bash --
+{
+set -eufo pipefail
+export LC_ALL=C
+usage () {
+    printf %s\\n "USAGE: $0 -- REMOTE DIRECTORY SHA" >&2
+    exit 1
+}
+if [[ "$#" -ne 4 ]] || [[ "x$1" != 'x--' ]]; then usage; fi
+remote=$2 directory=$3 sha=$4
+success=no
+trap '[ "$success" = yes ] || rm -rf -- "$directory"' EXIT
+[[ ${#sha} -eq 40 ]] || [[ ${#sha} -eq 64 ]] || usage
+[[ $sha =~ ^[0-9a-f]+$ ]] || usage
+if [[ -d "$directory" ]]; then
+    git clone --no-checkout -- "$remote" "$directory"
+fi
+git -C "$directory" checkout "$sha"
+git update-ref FETCH_HEAD "$sha"
+git reset --hard "$sha"
+success=yes
+}

--- a/build-infra/safe-checkout-sha
+++ b/build-infra/safe-checkout-sha
@@ -15,7 +15,8 @@ trap '[ "$success" = yes ] || rm -rf -- "$directory"' EXIT
 if [[ -d "$directory" ]]; then
     git clone --no-checkout -- "$remote" "$directory"
 fi
-git -C "$directory" checkout "$sha"
+cd -- "$directory"
+git checkout "$sha"
 git update-ref FETCH_HEAD "$sha"
 git reset --hard "$sha"
 success=yes

--- a/build-infra/safe-checkout-sha
+++ b/build-infra/safe-checkout-sha
@@ -1,5 +1,4 @@
 #!/bin/bash --
-{
 set -eufo pipefail
 export LC_ALL=C
 usage () {
@@ -20,4 +19,3 @@ git checkout "$sha"
 git update-ref FETCH_HEAD "$sha"
 git reset --hard "$sha"
 success=yes
-}


### PR DESCRIPTION
Verifying that a git commit has a valid tag pointing to it is complex.
Instead, just checkout a specific SHA and let `make get-sources` do the
heavy lifting.