### PR TITLE
Mass replace: ‘/var/run’ → ‘/run’

### DIFF
--- a/build-infra/keys-vm.sls
+++ b/build-infra/keys-vm.sls
@@ -2,6 +2,6 @@
   file.managed:
     - contents: |
         #!/bin/sh
-        touch /var/run/qubes-gpg-split/stat.$1
+        touch /run/qubes-gpg-split/stat.$1
     - mode: 0755
     - makedirs: True

--- a/build-infra/webhooks.nginx
+++ b/build-infra/webhooks.nginx
@@ -1,4 +1,4 @@
 location / {
     include uwsgi_params;
-    uwsgi_pass unix:/var/run/webhooks/webhooks.sock;
+    uwsgi_pass unix:/run/webhooks/webhooks.sock;
 }

--- a/build-infra/webhooks.rc-local
+++ b/build-infra/webhooks.rc-local
@@ -6,8 +6,8 @@ iptables -I INPUT -p tcp -s 140.82.112.0/20 --dport 80 -j ACCEPT
 ln -s /rw/config/webhooks.nginx /etc/nginx/default.d/webhooks.conf
 ln -s /home/user/webhooks/webhooks.service /etc/systemd/system/webhooks.service
 
-mkdir -p /var/run/webhooks
-chown user:nginx /var/run/webhooks
+mkdir -p /run/webhooks
+chown user:nginx /run/webhooks
 
 systemctl daemon-reload
 systemctl --no-block start webhooks.service


### PR DESCRIPTION
The former is deprecated in systemd.

Part of QubesOS/qubes-issues#6315.