### PR TITLE
Use supported version of Fedora by default

### DIFF
--- a/build-infra/dom0.sls
+++ b/build-infra/dom0.sls
@@ -5,7 +5,7 @@
     - present:
       - label: green
     - prefs:
-      - template: {{ salt['pillar.get']('build-infra:logs-template', 'fedora-33') }}
+      - template: {{ salt['pillar.get']('build-infra:logs-template', 'fedora-34') }}
       - netvm: {{ salt['pillar.get']('build-infra:logs-netvm', 'sys-firewall') }}
 {%- endfor %}
 
@@ -17,7 +17,7 @@ build-{{env}}:
     - present:
       - label: green
     - prefs:
-      - template: {{ salt['pillar.get']('build-infra:build-template', 'fedora-33') }}
+      - template: {{ salt['pillar.get']('build-infra:build-template', 'fedora-34') }}
       - netvm: {{ salt['pillar.get']('build-infra:build-netvm', 'sys-whonix') }}
 
 {% if salt['pillar.get']('build-infra:build-envs:' + env + ':volume-size') %}
@@ -31,7 +31,7 @@ keys-{{env}}:
     - present:
       - label: black
     - prefs:
-      - template: {{ salt['pillar.get']('build-infra:keys-template', 'fedora-33-minimal') }}
+      - template: {{ salt['pillar.get']('build-infra:keys-template', 'fedora-34-minimal') }}
       - netvm: none
 
 /etc/qubes-rpc/policy/qubesbuilder.LogReceived+build-{{env}}:

--- a/build-infra/init.top
+++ b/build-infra/init.top
@@ -1,9 +1,9 @@
 base:
   dom0:
     - build-infra.dom0
-  {{ salt['pillar.get']('build-infra:build-template', 'fedora-33') }}:
+  {{ salt['pillar.get']('build-infra:build-template', 'fedora-34') }}:
     - build-infra.template-build
-  {{ salt['pillar.get']('build-infra:keys-template', 'fedora-33-minimal') }}:
+  {{ salt['pillar.get']('build-infra:keys-template', 'fedora-34-minimal') }}:
     - build-infra.template-keys
 {%- for log in salt['pillar.get']('build-infra:build-envs', {}).values()|list|map(attribute='logs')|unique|list %}
   {{log}}:

--- a/build-infra/webhooks.top
+++ b/build-infra/webhooks.top
@@ -1,6 +1,6 @@
 base:
   # assume sys-net is on fedora-33 template
-  fedora-33:
+  fedora-34:
     - build-infra.template-net
   {{ salt['pillar.get']('build-infra:netvm', 'sys-net') }}:
     - build-infra.webhooks-base


### PR DESCRIPTION
This should probably be in a single place so that it is easy to modify.

Fixes QubesOS/qubes-issues#7128.