### PR TITLE
Remove duplicate package to be installed

### DIFF
--- a/build-infra/template-build.sls
+++ b/build-infra/template-build.sls
@@ -33,7 +33,6 @@ builder-dependencies:
       - bison
 # extra for builderv2
       - python3-packaging
-      - qubes-gpg-split
       - python3-pathspec
       - python3-debian
       - python3-pygithub


### PR DESCRIPTION
Newer salt (Fedora 38) complains and fails about providing list with duplicates.