### PR TITLE
ssh-proxy: support non-22 ports via local.ConnectSSH+host_port

### DIFF
--- a/build-infra/build-vm-ssh-proxy.sls
+++ b/build-infra/build-vm-ssh-proxy.sls
@@ -8,7 +8,7 @@
             ControlMaster auto
             ControlPath ~/.ssh/ctl-%r@%h:%p
             ControlPersist 60s
-            ProxyCommand /usr/bin/qrexec-client-vm {{ salt['pillar.get']('build-infra:netvm', 'sys-net') }} local.ConnectSSH+%h
+            ProxyCommand /usr/bin/qrexec-client-vm {{ salt['pillar.get']('build-infra:netvm', 'sys-net') }} local.ConnectSSH+%h+%p
             UseRoaming no
 
 /home/user/.ssh:

--- a/build-infra/build2-vm.sls
+++ b/build-infra/build2-vm.sls
@@ -202,6 +202,7 @@ commands-keyring:
         Host {{host}}
           HostName {{host}}
           User {{config.ssh_user}}
+          Port {{ config.get('ssh_port', 22) }}
 {% endfor %}
     - mode: 0755
     - makedirs: True

--- a/build-infra/ssh-proxy-dom0.sls
+++ b/build-infra/ssh-proxy-dom0.sls
@@ -1,20 +1,31 @@
-{% set hosts = ['github.com'] %}
-{% for host in salt['pillar.get']('build-infra:remote-hosts', {}).keys() %}
-{% do hosts.append(host) %}
+{% set hosts = {'github.com': 22} %}
+
+{% for host, cfg in salt['pillar.get']('build-infra:remote-hosts', {}).items() %}
+{%   if cfg is mapping %}
+{%     do hosts.update({host: cfg.get('ssh_port', 22)}) %}
+{%   else %}
+{%     do hosts.update({host: 22}) %}
+{%   endif %}
 {% endfor %}
 
-{% for host in hosts %}
-/etc/qubes-rpc/policy/local.ConnectSSH+{{host}}:
-  file.managed:
-    - contents:
-{%- for env in salt['pillar.get']('build-infra:build-envs', {}).keys() %}
-        - build-{{env}} {{ salt['pillar.get']('build-infra:netvm', 'sys-net') }} allow
-{% endfor %}
+{% set netvm = salt['pillar.get']('build-infra:netvm', 'sys-net') %}
+{% set envs = salt['pillar.get']('build-infra:build-envs', {}).keys() | list %}
 
-{% endfor %}
-
-/etc/qubes-rpc/policy/local.ConnectSSH:
+/etc/qubes/policy.d/30-local-connectssh.policy:
   file.managed:
     - makedirs: True
-    - contents:
-      - $anyvm $anyvm deny
+    - contents: |
+{%- for host, port in hosts.items() %}
+{%-   for env in envs %}
+        local.ConnectSSH +{{host}}+{{port}} build-{{env}} {{netvm}} allow
+{%-   endfor %}
+{%- endfor %}
+        local.ConnectSSH * @anyvm @anyvm deny
+
+{# remove legacy /etc/qubes-rpc/policy/ files this state used to manage #}
+/etc/qubes-rpc/policy/local.ConnectSSH:
+  file.absent
+{% for host in hosts.keys() %}
+/etc/qubes-rpc/policy/local.ConnectSSH+{{host}}:
+  file.absent
+{% endfor %}

--- a/build-infra/ssh-proxy.sls
+++ b/build-infra/ssh-proxy.sls
@@ -2,6 +2,8 @@
   file.managed:
     - contents:
       - "#!/bin/sh"
-      - exec /bin/socat - TCP:"$1":22
+      - 'host="${1%+*}"'
+      - 'port="${1##*+}"'
+      - 'exec /bin/socat - TCP:"$host":"$port"'
     - mode: 0755
     - makedirs: True

--- a/pillar/build-infra/init.sls
+++ b/pillar/build-infra/init.sls
@@ -66,7 +66,16 @@ build-infra:
 #     fedora1: {}
 #     fedora2: {}
 
-# list of remote hosts used to push packages
+# List of remote hosts used to push packages.
+# Set 'ssh_port' to reach a host on a non-22 port; the
+# qrexec call uses local.ConnectSSH+host+port and the
+# generated ~/.ssh/config carries 'Port' per host.
+# Default is port 22.
+#
+# Example:
+#   qubes.notset.fr:
+#       ssh_user: user
+#       ssh_port: 2222
   remote-hosts:
     yum.qubes-os.org:
         ssh_user: user


### PR DESCRIPTION
Service argument now passes both host and port (separated by '+').